### PR TITLE
refactor: 강의 목록 렌더링 로직을 CourseListView 컴포넌트로 분리

### DIFF
--- a/src/components/CourseListView.jsx
+++ b/src/components/CourseListView.jsx
@@ -1,0 +1,40 @@
+import { Container, Grid, Center, Pagination } from '@mantine/core';
+import CourseCard from './CourseCard';
+
+const ITEMS_PER_PAGE = 40;
+
+function CourseListView({ title, description, courses, activePage, setActivePage }) {
+    const totalPages = Math.ceil(courses.length / ITEMS_PER_PAGE);
+    const startIndex = (activePage - 1) * ITEMS_PER_PAGE;
+    const endIndex = startIndex + ITEMS_PER_PAGE;
+    const currentCourses = courses.slice(startIndex, endIndex);
+
+    return (
+        <Container size="xl" py="md">
+            {title && <h2>{title}</h2>}
+            {description && (
+                <p style={{ color: '#868e96', marginBottom: 16 }}>{description}</p>
+            )}
+
+            <Grid gutter="lg">
+                {currentCourses.map((course) => (
+                    <Grid.Col key={course.courseCode} span={2.4}>
+                        <CourseCard {...course} />
+                    </Grid.Col>
+                ))}
+            </Grid>
+
+            <Center mt="xl">
+                <Pagination
+                    value={activePage}
+                    onChange={setActivePage}
+                    total={totalPages}
+                    color="#00c471"
+                    withEdges
+                />
+            </Center>
+        </Container>
+    );
+}
+
+export default CourseListView;

--- a/src/pages/Courses.jsx
+++ b/src/pages/Courses.jsx
@@ -2,11 +2,8 @@ import { useParams } from 'react-router-dom';
 import { useState } from 'react';
 import CategoryTabs from '../components/CategoryTabs';
 import FilterBar from '../components/FilterBar';
-import CourseCard from '../components/CourseCard';
+import CourseListView from '../components/CourseListView';
 import courses from '../data/courses.json';
-import { Container, Grid, Pagination, Center } from '@mantine/core';
-
-const ITEMS_PER_PAGE = 40;
 
 function Courses() {
     const { category } = useParams();
@@ -28,34 +25,15 @@ function Courses() {
         return matchCategory && matchDifficulty && matchDiscount;
     });
 
-    const totalPages = Math.ceil(filteredCourses.length / ITEMS_PER_PAGE);
-    const startIndex = (activePage - 1) * ITEMS_PER_PAGE;
-    const endIndex = startIndex + ITEMS_PER_PAGE;
-    const currentCourses = filteredCourses.slice(startIndex, endIndex);
-
     return (
         <>
             <CategoryTabs />
             <FilterBar onFilterChange={handleFilterChange} />
-            <Container size='xl' py='md'>
-                <Grid gutter='lg'>
-                    {currentCourses.map((course) => (
-                        <Grid.Col key={course.courseCode} span={2.4}>
-                            <CourseCard {...course} />
-                        </Grid.Col>
-                    ))}
-                </Grid>
-
-                <Center mt='xl'>
-                    <Pagination
-                        value={activePage}
-                        onChange={setActivePage}
-                        total={totalPages}
-                        color='#00c471'
-                        withEdges
-                    />
-                </Center>
-            </Container>
+            <CourseListView
+                courses={filteredCourses}
+                activePage={activePage}
+                setActivePage={setActivePage}
+            />
         </>
     );
 }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,11 +1,8 @@
 import { useState } from 'react';
 import CategoryTabs from '../components/CategoryTabs';
 import FilterBar from '../components/FilterBar';
-import CourseCard from '../components/CourseCard';
+import CourseListView from '../components/CourseListView';
 import courses from '../data/courses.json';
-import { Container, Grid, Pagination, Center } from '@mantine/core';
-
-const ITEMS_PER_PAGE = 40;
 
 const Home = () => {
     const [filters, setFilters] = useState({ difficulty: [], discounted: false });
@@ -25,34 +22,15 @@ const Home = () => {
         return matchDifficulty && matchDiscount;
     });
 
-    const totalPages = Math.ceil(filteredCourses.length / ITEMS_PER_PAGE);
-    const startIndex = (activePage - 1) * ITEMS_PER_PAGE;
-    const endIndex = startIndex + ITEMS_PER_PAGE;
-    const currentCourses = filteredCourses.slice(startIndex, endIndex);
-
     return (
         <>
             <CategoryTabs />
             <FilterBar onFilterChange={handleFilterChange} />
-            <Container size='xl' py='md'>
-                <Grid gutter='lg'>
-                    {currentCourses.map((course) => (
-                        <Grid.Col key={course.courseCode} span={2.4}>
-                            <CourseCard {...course} />
-                        </Grid.Col>
-                    ))}
-                </Grid>
-
-                <Center mt='xl'>
-                    <Pagination
-                        value={activePage}
-                        onChange={setActivePage}
-                        total={totalPages}
-                        color='#00c471'
-                        withEdges
-                    />
-                </Center>
-            </Container>
+            <CourseListView
+                courses={filteredCourses}
+                activePage={activePage}
+                setActivePage={setActivePage}
+            />
         </>
     );
 };

--- a/src/pages/Search.jsx
+++ b/src/pages/Search.jsx
@@ -1,14 +1,11 @@
 import { useSearchParams } from 'react-router-dom';
 import { useState, useMemo } from 'react';
-import { Container, Grid, Center, Pagination, Title, Text } from '@mantine/core';
 import CategoryTabs from '../components/CategoryTabs';
 import FilterBar from '../components/FilterBar';
-import CourseCard from '../components/CourseCard';
-import CATEGORIES from '../data/courses.json';
+import CourseListView from '../components/CourseListView';
+import courses from '../data/courses.json';
 
-const ITEMS_PER_PAGE = 40;
-
-function Search() {
+const Search = () => {
     const [searchParams] = useSearchParams();
     const keyword = searchParams.get('s')?.toLowerCase() || '';
 
@@ -21,7 +18,7 @@ function Search() {
     };
 
     const filteredCourses = useMemo(() => {
-        return CATEGORIES.filter((course) => {
+        return courses.filter((course) => {
             const matchKeyword = keyword === '' || course.title.toLowerCase().includes(keyword);
             const matchDifficulty =
                 filters.difficulty.length === 0 || filters.difficulty.includes(course.level);
@@ -32,42 +29,19 @@ function Search() {
         });
     }, [keyword, filters]);
 
-    const totalPages = Math.ceil(filteredCourses.length / ITEMS_PER_PAGE);
-    const startIndex = (activePage - 1) * ITEMS_PER_PAGE;
-    const endIndex = startIndex + ITEMS_PER_PAGE;
-    const currentCourses = filteredCourses.slice(startIndex, endIndex);
-
     return (
         <>
             <CategoryTabs />
-            <Container size='xl' py='md'>
-                <Title order={2} mb='xs'>‘{keyword}’ 검색 결과</Title>
-                <Text mb='md' size='sm' c='dimmed'>
-                    {filteredCourses.length}개의 강의가 검색되었습니다.
-                </Text>
-
-                <FilterBar onFilterChange={handleFilterChange} />
-
-                <Grid gutter='lg'>
-                    {currentCourses.map((course) => (
-                        <Grid.Col key={course.courseCode} span={2.4}>
-                            <CourseCard {...course} />
-                        </Grid.Col>
-                    ))}
-                </Grid>
-
-                <Center mt='xl'>
-                    <Pagination
-                        value={activePage}
-                        onChange={setActivePage}
-                        total={totalPages}
-                        color='#00c471'
-                        withEdges
-                    />
-                </Center>
-            </Container>
+            <CourseListView
+                title={`‘${keyword}’ 검색 결과`}
+                description={`${filteredCourses.length}개의 강의가 검색되었습니다.`}
+                courses={filteredCourses}
+                activePage={activePage}
+                setActivePage={setActivePage}
+            />
+            <FilterBar onFilterChange={handleFilterChange} />
         </>
     );
-}
+};
 
 export default Search;


### PR DESCRIPTION
- Home, Courses, Search 페이지의 중복된 강의 카드, 그리드, 페이지네이션 렌더링 로직을 CourseListView로 분리
- 각 페이지에서는 필터 로직 및 상태 관리를 유지하여 의도와 책임을 명확히 함