### PR TITLE
refactor(layout): 레이아웃 별 Route 분리 및 SearchContext 도입으로 props 드릴링 제거

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,51 +11,38 @@ import FindId from './pages/signin/find/Id';
 import Likes from './pages/my/Likes';
 import MyCourses from './pages/my/Courses';
 import Notfound from './pages/Notfound';
-import { Routes, Route, useNavigate } from 'react-router-dom'
-import Topbar from './layout/Topbar';
-import Header from './layout/Header/Header';
-import ChannelTalkButton from './layout/ChannelTalkButton';
-import Footer from './layout/Footer/Footer';
+import { Routes, Route } from 'react-router-dom'
 import { MantineProvider } from '@mantine/core';
 import { AuthProvider } from './contexts/AuthContext';
+import { SearchProvider } from './contexts/SearchContext';
+import MainLayout from './layout/MainLayout';
 import '@mantine/core/styles.css';
 import Questions from './pages/community/questions';
-import { useState } from 'react';
 
 function App() {
-  const [query, setQuery] = useState('');
-  const navigate = useNavigate();
-
-  const handleSearch = () => {
-    if (query.trim()) {
-      navigate(`/search?s=${encodeURIComponent(query.trim())}`);
-    }
-  };
-
   return (
     <MantineProvider>
       <AuthProvider>
-        <Topbar />
-        <Header query={query} setQuery={setQuery} onSearch={handleSearch} />
-        <ChannelTalkButton />
         <Routes>
-          <Route path='/' element={<Home />} />
-          <Route path="/courses/:category" element={<CourseList />} />
-          <Route path='/course/:courseCode' element={<CourseDetail />} />
-          <Route path="/course/:courseCode/:lectureCode" element={<LecturePlayer />} />
-          <Route path='/search' element={<Search />} />
-          <Route path='/community/questions' element={<Questions />} />
-          <Route path='/carts' element={<Carts />} />
+          <Route element={<SearchProvider><MainLayout /></SearchProvider>}>
+            <Route path='/' element={<Home />} />
+            <Route path='/courses/:category' element={<CourseList />} />
+            <Route path='/course/:courseCode' element={<CourseDetail />} />
+            <Route path='/search' element={<Search />} />
+            <Route path='/carts' element={<Carts />} />
+            <Route path='/my/likes' element={<Likes />} />
+            <Route path='/my/courses' element={<MyCourses />} />
+            <Route path='/community/questions' element={<Questions />} />
+          </Route>
+
+          <Route path='/course/:courseCode/:lectureCode' element={<LecturePlayer />} />
           <Route path='/signup' element={<Signup />} />
           <Route path='/signin/find/password' element={<FindPassword />} />
           <Route path='/signin/find/id' element={<FindId />} />
-          <Route path='/my/likes' element={<Likes />} />
-          <Route path='/my/courses' element={<MyCourses />} />
           <Route path='*' element={<Notfound />} />
         </Routes>
-        <Footer />
       </AuthProvider>
-    </MantineProvider>
+    </MantineProvider >
   )
 }
 

--- a/src/contexts/SearchContext.jsx
+++ b/src/contexts/SearchContext.jsx
@@ -1,0 +1,21 @@
+import { createContext, useContext, useState } from 'react';
+
+const SearchContext = createContext();
+
+export const SearchProvider = ({ children }) => {
+    const [query, setQuery] = useState('');
+
+    return (
+        <SearchContext.Provider value={{ query, setQuery }}>
+            {children}
+        </SearchContext.Provider>
+    );
+};
+
+export const useSearch = () => {
+    const context = useContext(SearchContext);
+    if (!context) {
+        throw new Error('useSearch must be used within a SearchProvider');
+    }
+    return context;
+};

--- a/src/layout/Header/Header.jsx
+++ b/src/layout/Header/Header.jsx
@@ -11,11 +11,13 @@ import LoginButton from '../../components/LoginButton';
 import NavBarRight from './NavBarRight';
 import LoginModal from '../../components/LoginModal';
 import { useState } from 'react';
+import { useSearch } from '../../contexts/SearchContext';
 import { useAuth } from '../../contexts/AuthContext';
 
-function Header({ query, setQuery, onSearch }) {
+function Header() {
     const { user, logout } = useAuth();
     const [loginModalOpened, setLoginModalOpened] = useState(false);
+    const { query, setQuery } = useSearch();
     const isLoggedIn = !!user;
 
     return (
@@ -28,7 +30,7 @@ function Header({ query, setQuery, onSearch }) {
                             <NavBarLeft />
                         </Group>
 
-                        <SearchInput query={query} setQuery={setQuery} onSearch={onSearch} />
+                        <SearchInput query={query} setQuery={setQuery} />
 
                         <Group spacing='sm'>
                             <LanguageButton />

--- a/src/layout/Header/SearchInput.jsx
+++ b/src/layout/Header/SearchInput.jsx
@@ -1,11 +1,20 @@
 import { TextInput } from '@mantine/core';
 import { TbSearch } from 'react-icons/tb';
 import { ActionIcon } from '@mantine/core';
+import { useNavigate } from 'react-router-dom';
 
-function SearchInput({ query, setQuery, onSearch }) {
+function SearchInput({ query, setQuery }) {
+    const navigate = useNavigate();
+
+    const handleSearch = () => {
+        if (query.trim()) {
+            navigate(`/search?s=${encodeURIComponent(query.trim())}`);
+        }
+    };
+
     const handleKeyDown = (e) => {
         if (e.key === 'Enter') {
-            onSearch();
+            handleSearch();
         }
     };
 
@@ -18,7 +27,7 @@ function SearchInput({ query, setQuery, onSearch }) {
             radius='md'
             size='sm'
             rightSection={
-                <ActionIcon onClick={onSearch} variant='transparent'>
+                <ActionIcon onClick={handleSearch} variant='transparent'>
                     <TbSearch size={20} color='black' />
                 </ActionIcon>
             }

--- a/src/layout/MainLayout.jsx
+++ b/src/layout/MainLayout.jsx
@@ -1,0 +1,19 @@
+import { Outlet } from 'react-router-dom';
+import Topbar from './Topbar';
+import Header from './Header/Header';
+import Footer from './Footer/Footer';
+import ChannelTalkButton from './ChannelTalkButton';
+
+function MainLayout() {
+    return (
+        <>
+            <Topbar />
+            <Header />
+            <ChannelTalkButton />
+            <Outlet />
+            <Footer />
+        </>
+    );
+}
+
+export default MainLayout;


### PR DESCRIPTION
- Notfound, Signup, 강의 재생 등 페이지에 공통 레이아웃 제외
- MainLayout 컴포넌트 도입하여 Topbar, Header, Footer, ChannelTalkButton 공통 적용
- 검색 상태 관리를 위한 SearchContext 생성 및 Header, Search 페이지에 적용
- query, setQuery, handleSearch 등의 props 드릴링 제거
- 확장성과 유지보수성을 고려한 구조 개선