### PR TITLE
feat(auth): 비밀번호 재설정 및 변경 기능 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,8 +6,9 @@ import CartsPage from './pages/carts';
 import CoursePage from './pages/course';
 import CoursesPage from './pages/Courses';
 import LecturePlayer from './pages/lecturePlayer';
-import FindPassword from './pages/signin/find/Password';
 import FindId from './pages/signin/find/Id';
+import FindPassword from './pages/signin/find/Password';
+import UpdatePassword from './pages/signin/update/Password';
 import Likes from './pages/my/Likes';
 import MyCourses from './pages/my/Courses';
 import Notfound from './pages/Notfound';
@@ -42,8 +43,9 @@ function App() {
 
             <Route path='/course/:courseCode/:lectureCode' element={<LecturePlayer />} />
             <Route path='/signup' element={<Signup />} />
-            <Route path='/signin/find/password' element={<FindPassword />} />
             <Route path='/signin/find/id' element={<FindId />} />
+            <Route path='/signin/find/password' element={<FindPassword />} />
+            <Route path='/signin/update/password' element={<UpdatePassword />} />
             <Route path='*' element={<Notfound />} />
           </Routes>
         </AuthProvider>

--- a/src/hooks/useCheckEmailExists.jsx
+++ b/src/hooks/useCheckEmailExists.jsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import supabase from '../lib/supabaseClient';
+
+function useCheckEmailExists() {
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+
+    const checkEmail = async (email) => {
+        setLoading(true);
+        setError(null);
+
+        const { data, error } = await supabase
+            .from('user_profiles')
+            .select('id')
+            .eq('email', email.trim().toLowerCase())
+            .maybeSingle();
+
+        setLoading(false);
+
+        if (error) {
+            setError(error.message);
+            return false;
+        }
+
+        return !!data;
+    };
+
+    return { loading, error, checkEmail };
+}
+
+export default useCheckEmailExists;

--- a/src/pages/signin/update/Password.jsx
+++ b/src/pages/signin/update/Password.jsx
@@ -1,0 +1,124 @@
+import {
+    Box,
+    Button,
+    PasswordInput,
+    Stack,
+    Text,
+    Card,
+} from '@mantine/core';
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import supabase from '../../../lib/supabaseClient';
+import { validatePassword, validateConfirmPassword } from '../../../utils/validators';
+import useFormRedirect from '../../../hooks/useFormRedirect';
+
+function Password() {
+    const [searchParams] = useSearchParams();
+    const { scheduleRedirect } = useFormRedirect('/');
+
+    const [password, setPassword] = useState('');
+    const [confirmPassword, setConfirmPassword] = useState('');
+    const [passwordErrors, setPasswordErrors] = useState([]);
+    const [confirmError, setConfirmError] = useState('');
+    const [successMessage, setSuccessMessage] = useState('');
+    const [errorMessage, setErrorMessage] = useState('');
+
+    useEffect(() => {
+        const token = searchParams.get('access_token');
+        const type = searchParams.get('type');
+
+        if (token && type === 'recovery') {
+            supabase.auth.setSession({
+                access_token: token,
+                refresh_token: '',
+            });
+        }
+    }, [searchParams]);
+
+    const handleSubmit = async () => {
+        const passwordResult = validatePassword(password);
+        const confirmResult = validateConfirmPassword(password, confirmPassword);
+
+        setPasswordErrors(passwordResult.messages);
+        setConfirmError(confirmResult.message);
+
+        if (!passwordResult.isValid || !confirmResult.isValid) return;
+
+        const { error } = await supabase.auth.updateUser({ password });
+
+        if (error) {
+            setErrorMessage('비밀번호 변경 중 오류가 발생했습니다.');
+            return;
+        }
+
+        setSuccessMessage('비밀번호가 성공적으로 변경되었습니다. 로그인해주세요.');
+        scheduleRedirect();
+    };
+
+    return (
+        <Box maw={400} mx="auto">
+            <h2>비밀번호 변경</h2>
+
+            {successMessage && (
+                <Card withBorder shadow="sm" mb="md" padding="md" radius="md" bg="green.0">
+                    <Text c="green.8" fw={600}>{successMessage}</Text>
+                </Card>
+            )}
+
+            {errorMessage && (
+                <Card withBorder shadow="sm" mb="md" padding="md" radius="md" bg="red.0">
+                    <Text c="red.8" fw={600}>{errorMessage}</Text>
+                </Card>
+            )}
+
+            <Stack>
+                <PasswordInput
+                    label="새 비밀번호"
+                    placeholder="********"
+                    value={password}
+                    onChange={(e) => {
+                        const val = e.currentTarget.value;
+                        setPassword(val);
+                        const result = validatePassword(val);
+                        setPasswordErrors(result.messages);
+                        setConfirmError(validateConfirmPassword(val, confirmPassword).message);
+                    }}
+                />
+
+                <Stack spacing={4}>
+                    {[
+                        '영문/숫자/특수문자 중 2가지 이상 포함',
+                        '8자 이상 32자 이하 입력 (공백 제외)',
+                        '연속 3자 이상 동일한 문자/숫자 제외',
+                    ].map((rule, idx) => (
+                        <Text
+                            key={idx}
+                            size="xs"
+                            c={passwordErrors.includes(rule) ? 'red' : password ? 'green' : 'gray'}
+                        >
+                            {passwordErrors.includes(rule) ? '✗' : '✓'} {rule}
+                        </Text>
+                    ))}
+                </Stack>
+
+                <PasswordInput
+                    label="비밀번호 확인"
+                    placeholder="********"
+                    value={confirmPassword}
+                    onChange={(e) => {
+                        const val = e.currentTarget.value;
+                        setConfirmPassword(val);
+                        setConfirmError(validateConfirmPassword(password, val).message);
+                    }}
+                    error={confirmError}
+                />
+
+                <Button fullWidth mt="md" onClick={handleSubmit} color="green">
+                    비밀번호 변경
+                </Button>
+            </Stack>
+        </Box>
+    );
+}
+
+export default Password;


### PR DESCRIPTION
- useCheckEmailExists 훅 추가
  - Supabase `user_profiles` 테이블에서 이메일 존재 여부 확인
- /signin/forgot/password 페이지 구현
  - 이메일 유효성 검사 후 Supabase `resetPasswordForEmail` API 호출
  - 이메일 존재 여부에 따라 오류 메시지 처리
  - 이메일 발송 성공 시 홈으로 리디렉션
- /signin/update/password 페이지 구현
  - `access_token` 쿼리 파라미터로 세션 설정
  - 비밀번호/비밀번호 확인 입력 및 유효성 검사
  - Supabase `updateUser`로 비밀번호 변경 처리
  - 성공 시 성공 메시지 표시 후 로그인 페이지로 리디렉션